### PR TITLE
feat:实现openPhotoPicker方法适配Harmony OS

### DIFF
--- a/harmony/permissions/src/main/cpp/PermissionsTurboModule.cpp
+++ b/harmony/permissions/src/main/cpp/PermissionsTurboModule.cpp
@@ -39,6 +39,11 @@ static jsi::Value __hostFunction_RTNPermissionsTurboModule_openSettings(jsi::Run
                                                                            const jsi::Value *args, size_t count) {
     return static_cast<ArkTSTurboModule &>(turboModule).callAsync(rt, "openSettings", args, count);
 }
+static jsi::Value __hostFunction_RTNPermissionsTurboModule_openPhotoPicker(jsi::Runtime &rt,
+                                                                           react::TurboModule &turboModule,
+                                                                           const jsi::Value *args, size_t count) {
+    return static_cast<ArkTSTurboModule &>(turboModule).callAsync(rt, "openPhotoPicker", args, count);
+}
 
 RTNPermissionsTurboModule::RTNPermissionsTurboModule(const ArkTSTurboModule::Context ctx, const std::string name)
     : ArkTSTurboModule(ctx, name) {
@@ -49,4 +54,5 @@ RTNPermissionsTurboModule::RTNPermissionsTurboModule(const ArkTSTurboModule::Con
     methodMap_["requestNotifications"] = MethodMetadata{0, __hostFunction_RTNPermissionsTurboModule_requestNotifications};
     methodMap_["checkNotifications"] = MethodMetadata{0, __hostFunction_RTNPermissionsTurboModule_checkNotifications};
     methodMap_["openSettings"] = MethodMetadata{0, __hostFunction_RTNPermissionsTurboModule_openSettings};
+    methodMap_["openPhotoPicker"] = MethodMetadata{0, __hostFunction_RTNPermissionsTurboModule_openPhotoPicker};
 }

--- a/harmony/permissions/src/main/ets/PermissionsModule.ts
+++ b/harmony/permissions/src/main/ets/PermissionsModule.ts
@@ -4,7 +4,7 @@ import { BusinessError } from '@kit.BasicServicesKit';
 import notificationManager from '@ohos.notificationManager';
 import Base from '@ohos.base';
 import { GrantStatus, NotificationsResponse } from './results';
-
+import { photoAccessHelper } from '@kit.MediaLibraryKit';
 
 export class PermissionsModule extends TurboModule {
   /**
@@ -156,6 +156,24 @@ export class PermissionsModule extends TurboModule {
       .catch((err) => {
         console.error(`Failed to startAbility. Code: ${err.code}, message: ${err.message}`);
       });
+  }
+  /**
+   * 用来打开图片选择
+   * */
+  async openPhotoPicker() {
+    try {
+      let PhotoSelectOptions = new photoAccessHelper.PhotoSelectOptions();
+      PhotoSelectOptions.MIMEType = photoAccessHelper.PhotoViewMIMETypes.IMAGE_TYPE;
+      PhotoSelectOptions.maxSelectNumber = 5;
+      let photoPicker = new photoAccessHelper.PhotoViewPicker();
+      photoPicker.select(PhotoSelectOptions).then((PhotoSelectResult: photoAccessHelper.PhotoSelectResult) => {
+      }).catch((err: BusinessError) => {
+        console.error(`PhotoViewPicker.select failed with err: ${err.code}, ${err.message}`);
+      });
+    } catch (error) {
+      let err: BusinessError = error as BusinessError;
+      console.error(`PhotoViewPicker failed with err: ${err.code}, ${err.message}`);
+    }
   }
 
   private checkStatus(status: number): GrantStatus {

--- a/src/methods.harmony.ts
+++ b/src/methods.harmony.ts
@@ -73,9 +73,7 @@ async function requestLocationAccuracy(): Promise<LocationAccuracy> {
  * 请求访问设备相册图片权限
 */
 async function openPhotoPicker(): Promise<void> {
-    return new Promise((_resolve, reject) => {
-        reject('openPhotoPicker is not supported on Harmony')
-    })
+    NativeModule.openPhotoPicker()
 }
 
 export const methods: Contract = {


### PR DESCRIPTION
# Summary

- Closes #5 
- 实现openPhotoPicker方法适配Harmony OS
- 通过调用Harmony OS的photoPicker实现openPhotoPicker方法


## Test Plan

RTNPermissions.openPhotoPicker( )调用方法，不需要获取任何权限


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [X] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)

<!-- Check completed item, when applicable, via: [X] -->