### PR TITLE
fix:修复opensetting打开设置页后jscarsh

### DIFF
--- a/harmony/permissions/src/main/ets/PermissionsModule.ts
+++ b/harmony/permissions/src/main/ets/PermissionsModule.ts
@@ -145,17 +145,13 @@ export class PermissionsModule extends TurboModule {
   /**
    * 用来打开设置页面引导用户到设置页面开启或关闭某些权限
    * */
-  openSettings(): void {
+  async openSettings(): Promise<void> {
     let context = this.ctx.uiAbilityContext;
     let want = {
       bundleName: 'com.huawei.hmos.settings',
       abilityName: 'com.huawei.hmos.settings.MainAbility'
     };
-    context.startAbility(want)
-      .then(() => {})
-      .catch((err) => {
-        console.error(`Failed to startAbility. Code: ${err.code}, message: ${err.message}`);
-      });
+    await context.startAbility(want)
   }
   /**
    * 用来打开图片选择


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

- closes #8  
- 修复opensetting打开设置页后jscarsh
- 将openSettings改为异步函数，返回的值为Promise<void>

## Test Plan

```js
let check = await RTNPermissions.openSettings();
````

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
